### PR TITLE
Improve Volo adapter caching and node reuse

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 #[derive(Clone, Debug)]
 pub struct Endpoint {
@@ -29,5 +29,21 @@ impl Node {
             fail: AtomicU64::new(0),
             last_rtt_ns: AtomicU64::new(0),
         }
+    }
+
+    pub fn clone_with_metadata(&self, endpoint: Endpoint, weight: u32) -> Self {
+        let node = Self::new(endpoint, weight);
+        let in_flight = self.in_flight.load(Ordering::Relaxed);
+        let success = self.success.load(Ordering::Relaxed);
+        let fail = self.fail.load(Ordering::Relaxed);
+        let last_rtt = self.last_rtt_ns.load(Ordering::Relaxed);
+
+        let cloned = node;
+        cloned.in_flight.store(in_flight, Ordering::Relaxed);
+        cloned.success.store(success, Ordering::Relaxed);
+        cloned.fail.store(fail, Ordering::Relaxed);
+        cloned.last_rtt_ns.store(last_rtt, Ordering::Relaxed);
+
+        cloned
     }
 }


### PR DESCRIPTION
## Summary
- add stable instance hashing and reuse cached node state when rebuilding pickers in the Volo adapter
- incorporate endpoint metadata into picker cache keys and target cache invalidation via discovery change events
- streamline response-time weighted selection and base the consistent hash ring on stable node ids

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68fa1c78aac08333a77c1bb744bfcf7f